### PR TITLE
Ignore the tmp directory when syncing files

### DIFF
--- a/build.files.xml
+++ b/build.files.xml
@@ -16,6 +16,7 @@
                    --mode=avz
                    --delete
                    --force
+                   --exclude=tmp
                    --exclude=cdn
                    --exclude=css
                    --exclude=ctools


### PR DESCRIPTION
We should ignore the tmp directory when syncing files.
